### PR TITLE
fix a crash on openfl graphics

### DIFF
--- a/src/animate/FlxAnimateFrames.hx
+++ b/src/animate/FlxAnimateFrames.hx
@@ -82,6 +82,11 @@ class FlxAnimateFrames extends FlxAtlasFrames
 			return content.replace(String.fromCharCode(0xFEFF), "");
 		}
 
+		final getGraphic = (path:String) ->
+		{
+			return #if sys FlxGraphic.fromBitmapData(openfl.display.BitmapData.fromFile(path), false, path); #else FlxG.bitmap.add(path); #end
+		}
+
 		var animation:AnimationJson = Json.parse(getTextFromPath(path + "/Animation.json"));
 
 		var frames = new FlxAnimateFrames(null);
@@ -93,7 +98,7 @@ class FlxAnimateFrames extends FlxAtlasFrames
 		{
 			var id = sm.split("spritemap")[1].split(".")[0];
 
-			var graphic = FlxG.bitmap.add(path + '/spritemap$id.png');
+			var graphic = getGraphic(path + '/spritemap$id.png');
 			var atlas = new FlxAtlasFrames(graphic);
 
 			var smContent = getTextFromPath(path + '/spritemap$id.json');

--- a/src/animate/FlxAnimateFrames.hx
+++ b/src/animate/FlxAnimateFrames.hx
@@ -84,7 +84,7 @@ class FlxAnimateFrames extends FlxAtlasFrames
 
 		final getGraphic = (path:String) ->
 		{
-			return #if sys FlxGraphic.fromBitmapData(openfl.display.BitmapData.fromFile(path), false, path); #else FlxG.bitmap.add(path); #end
+			return #if (flixel < "5.9.0" && sys) FlxGraphic.fromBitmapData(openfl.display.BitmapData.fromFile(path), false, path); #else FlxG.bitmap.add(path); #end
 		}
 
 		var animation:AnimationJson = Json.parse(getTextFromPath(path + "/Animation.json"));


### PR DESCRIPTION
fixes a crash when trying to load a graphic that exists but not in openfl's asset system

there's probably a better way to go about this but at least the issue is brought up somewhere