### PR TITLE
fix anim FlxAnimateController override

### DIFF
--- a/src/animate/FlxAnimate.hx
+++ b/src/animate/FlxAnimate.hx
@@ -236,7 +236,7 @@ class FlxAnimate extends FlxSprite
 	override function destroy():Void
 	{
 		super.destroy();
-		anim = null;
+		anim = FlxDestroyUtil.destroy(anim);
 		library = null;
 		timeline = null;
 		stageBg = FlxDestroyUtil.destroy(stageBg);

--- a/src/animate/FlxAnimate.hx
+++ b/src/animate/FlxAnimate.hx
@@ -16,8 +16,15 @@ class FlxAnimate extends FlxSprite
 {
 	public static var drawDebugLimbs:Bool = false;
 
+	public var anim(default, set):FlxAnimateController = null;
+	private function set_anim(newController:FlxAnimateController):FlxAnimateController
+	{
+		anim = newController;
+		animation = anim;
+		return newController;
+	}
+
 	public var library(default, null):FlxAnimateFrames;
-	public var anim(default, null):FlxAnimateController;
 	public var isAnimate(default, null):Bool = false;
 	public var timeline:Timeline;
 


### PR DESCRIPTION
before, when you tried changing the FlxAnimateController to one made yourself, it would "*break" due to not setting animation to it too
of course you could fix this by adding `animation = anim;`, but that seemed a little tedious
to fix this, we just add a set_anim function so it can automatically do so

*it didn't crash or so, it just froze the animation, causing it to not properly play