### PR TITLE
Fix `applyStageMatrix` not accounting for the symbol instance scale

### DIFF
--- a/src/animate/FlxAnimate.hx
+++ b/src/animate/FlxAnimate.hx
@@ -71,9 +71,22 @@ class FlxAnimate extends FlxSprite
 	/**
 	 * Whether to apply the stage matrix of the Texture Atlas.
 	 * It also makes the sprite render with the bounds from Animate.
+	 * 
 	 * Take note that these bounds may not be accurate to flixel positions.
 	 */
 	public var applyStageMatrix(default, set):Bool = false;
+
+	/**
+	 * Wether to apply the stage matrix of the Texture Atlas before or after FlxSprite calculations.
+	 * Changes the behaviour of a sprite in relation to the position, scale and rotation of the matrix.
+	 * 
+	 * When set to ``false`` the stage matrix will apply before other FlxSprite matrix calculations,
+	 * as if the symbol was contained inside of the sprite.
+	 * 
+	 * When set to ``true`` the stage matrix will apply after FlxSprite matrix calculations,
+	 * as if the sprite was contained inside of the symbol.
+	 */
+	public var postStageMatrixApply:Bool = false;
 
 	/**
 	 * Whether to render the colored background rectangle found in Adobe Animate.
@@ -273,8 +286,15 @@ class FlxAnimate extends FlxSprite
 
 		if (doStageMatrix)
 		{
-			matrix.concat(library.matrix);
-			matrix.translate(timeline._bounds.x * library.matrix.a, timeline._bounds.y * library.matrix.d);
+			if (postStageMatrixApply)
+			{
+				matrix.translate(timeline._bounds.x, timeline._bounds.y);
+			}
+			else
+			{
+				matrix.concat(library.matrix);
+				matrix.translate(timeline._bounds.x * library.matrix.a, timeline._bounds.y * library.matrix.d);
+			}
 		}
 
 		matrix.translate(-origin.x, -origin.y);
@@ -290,6 +310,11 @@ class FlxAnimate extends FlxSprite
 		{
 			updateSkew();
 			matrix.concat(_skewMatrix);
+		}
+
+		if (doStageMatrix && postStageMatrixApply)
+		{
+			matrix.concat(library.matrix);
 		}
 
 		getScreenPosition(_point, camera);

--- a/src/animate/FlxAnimate.hx
+++ b/src/animate/FlxAnimate.hx
@@ -273,7 +273,8 @@ class FlxAnimate extends FlxSprite
 
 		if (doStageMatrix)
 		{
-			matrix.translate(timeline._bounds.x, timeline._bounds.y);
+			matrix.concat(library.matrix);
+			matrix.translate(timeline._bounds.x * library.matrix.a, timeline._bounds.y * library.matrix.d);
 		}
 
 		matrix.translate(-origin.x, -origin.y);
@@ -289,11 +290,6 @@ class FlxAnimate extends FlxSprite
 		{
 			updateSkew();
 			matrix.concat(_skewMatrix);
-		}
-
-		if (doStageMatrix) // TODO: add some way to customize the order of this thing
-		{
-			matrix.concat(library.matrix);
 		}
 
 		getScreenPosition(_point, camera);


### PR DESCRIPTION
I believe this fix was planned to be included in #20, but wasn't to prevent Funkin' from breaking. However, I think reintroducing it here would be okay now!! Having a sprite with `applyStageMatrix` enabled *and* a `scale` other than 1 seems pretty niche, so this should be fine.

The only place this breaks on Funkin' are the BG Tankmen, which are relatively trivial to fix!
<img width="677" height="606" alt="wawa-image" src="https://github.com/user-attachments/assets/713ea9c0-f4da-4cc7-8972-8a9a21afc7d9" />
